### PR TITLE
Fix import paths for Solr and Catalog modules

### DIFF
--- a/src/anol/anol.js
+++ b/src/anol/anol.js
@@ -13,8 +13,8 @@ register(proj4);
 
 import Helper from './helper.js';
 import Nominatim from './geocoder/nominatim.js';
-import Solr from './geocoder/Solr.js';
-import Catalog from './geocoder/Catalog.js';
+import Solr from './geocoder/solr.js';
+import Catalog from './geocoder/catalog.js';
 
 import AnolBaseLayer from './layer.js';
 import BaseWMS from './layer/basewms.js';
@@ -64,5 +64,3 @@ window.anol = {
     'helper': helper,
     'geocoder': geocoder
 };
-
-


### PR DESCRIPTION
This fixes the import paths for the `Solr` and `Catalog` modules to actually fix the failing build.