### PR TITLE
Fix Attribution Layers Sync

### DIFF
--- a/src/modules/attribution/attribution-directive.js
+++ b/src/modules/attribution/attribution-directive.js
@@ -77,7 +77,7 @@ angular.module('anol.attribution')
                         scope.tooltipDelay : 500;
                     scope.tooltipEnable = angular.isDefined(scope.tooltipEnable) ?
                         scope.tooltipEnable : !hasTouch;
-                    scope.layers = LayersService.flattedLayers();
+                    scope.layersService = LayersService;
 
                     ControlsService.addControl(
                         new anol.control.Control({

--- a/src/modules/attribution/templates/attribution.html
+++ b/src/modules/attribution/templates/attribution.html
@@ -1,7 +1,7 @@
 <div class="anol-attribution ol-unselectable ol-control">
     <ul ng-show="attributionVisible"
         class="list-unstyled">
-        <li ng-repeat="layer in layers | uniqueActiveAttribution" ng-bind-html="layer.attribution"></li>
+        <li ng-repeat="layer in layersService.flattedLayers() | uniqueActiveAttribution" ng-bind-html="layer.attribution"></li>
     </ul>
     <button ng-class="{'anol-info-white': !attributionVisible, 'glyphicon glyphicon-chevron-right': attributionVisible}"
             ng-click="attributionVisible=!attributionVisible"


### PR DESCRIPTION
The `anolAttribution` directive was not completely in sync with the layers provided by `LayersService`.  When adding a layer after the directive was already instantiated, the attribution for that layer was not being rendered. When removing an active layer, the attribution for that layer was still being rendered.

This was fixed by calling `flattedLayers()` on every render cycle.