### PR TITLE
Fix random order of user-added overlays

### DIFF
--- a/src/modules/map/layers-service.js
+++ b/src/modules/map/layers-service.js
@@ -199,7 +199,9 @@ angular.module('anol.map')
                     var overlayLayerIdx = self.overlayLayers.indexOf(group);
                     if(overlayLayerIdx > -1) {
                         self.overlayLayers.splice(overlayLayerIdx, 1);
-                        self.deletedOverlayLayers.push(group.name)
+                        if (!layer.catalogLayer) {
+                            self.deletedOverlayLayers.push(group.name)
+                        }
                     }   
                     angular.forEach(group.layers, function(_layer) {
                         // _layer.setVisible(false);
@@ -214,7 +216,9 @@ angular.module('anol.map')
                             handler(_layer);
                         });
                         _layer.removeOlLayer();
-                        self.deletedOverlayLayers.push(_layer.name);
+                        if (!layer.catalogLayer) {
+                            self.deletedOverlayLayers.push(_layer.name);
+                        }
                     });
                     return true;
                 } else {
@@ -254,7 +258,9 @@ angular.module('anol.map')
                                         _layer.layers.splice(overlayLayerIdx, 1);
                                     }
                                     layer.removeOlLayer();
-                                    self.deletedOverlayLayers.push(layer.name);
+                                    if (!layer.catalogLayer) {
+                                        self.deletedOverlayLayers.push(layer.name);
+                                    }
                                 }
                             });
                         }
@@ -520,7 +526,9 @@ angular.module('anol.map')
                     if (angular.isUndefined(layer)) {
                         layer = self.groupByName(overlayLayer);
                     }
-                    self.removeOverlayLayer(layer)
+                    if (angular.isDefined(layer)) {
+                        self.removeOverlayLayer(layer)
+                    }
                 });
             };
 
@@ -548,7 +556,7 @@ angular.module('anol.map')
                             return;
                         }
                     });
-                });  
+                });
                 this.reorderOverlayLayers();
             };  
 


### PR DESCRIPTION
Before this patch, it was possible to trigger an accidental random ordering of user-added overlays in an anol-based application. Steps for reproducing:

1. Add (multiple) catalog layers (CatalogService.addGroupToMap)
1. Remove a single catalog layer again (CatalogService.removeFromMap)
1. Save user settings (SaveSettingsService.save)
1. Reload the application
1. Load user settings (SaveSettingsService.applyLoadSettings)

I tracked down the cause of the random ordering to the fact that the removed catalog layer was present in the ``layerswitcher.deleted`` array of the saved user settings (step 3).  I believe this should not be the case. I assume that only non-catalog overlays should be exported here, as this allows the user settings to disable/delete pre-defined overlays. For catalog layers, this option doesn't seem to make sense.

In my case, ``SaveSettingsService`` would run into an exception during ``applyLoadSettings`` (step 5) when calling ``LayersService.deleteLayers(settings.layerswitcher.deleted)``, as the catalog layer to be deleted was not present in the ``LayersService``. As a consequence, ``applyLoadSettings`` would stop executing and ``LayersService.setLayerOrder`` would not be invoked, resulting in randomly ordered user overlays.

This patch does two things: 

- Avoid the exception by making the ``LayersService.deleteLayers`` more robust. Therefore, existing (broken) user settings will note cause the problem anymore.
- Avoid user-defined overlays in the ``layerswitcher.deleted`` array of the user settings in the first place by only adding non-catalog layers to ``deletedOverlayLayers`` in  ``LayersService``
