### PR TITLE
anolDraw: Live measure fixes

### DIFF
--- a/src/modules/draw/draw-directive.js
+++ b/src/modules/draw/draw-directive.js
@@ -51,7 +51,7 @@ angular.module('anol.draw')
                     pointTooltipPlacement: '@',
                     lineTooltipPlacement: '@',
                     polygonTooltipPlacement: '@',
-                    liveMeasure: '@'
+                    liveMeasure: '<'
                 },
                 template: function(tElement, tAttrs) {
                     if (tAttrs.templateUrl) {
@@ -134,7 +134,7 @@ angular.module('anol.draw')
                         var draw = new Draw({
                             source: source,
                             type: drawType,
-                            style: scope.liveMeasure !== 'true' ? undefined : function (feature) {
+                            style: !scope.liveMeasure ? undefined : function (feature) {
                                 const geometry = feature.getGeometry();
                                 if (geometry.getType() === 'Point' && draw.sketchFeature_) {
                                     const sketchGeometry = draw.sketchFeature_.getGeometry();
@@ -196,7 +196,7 @@ angular.module('anol.draw')
                         var selectInteraction = new Select({
                             toggleCondition: neverCondition,
                             layers: [layer],
-                            style: scope.liveMeasure !== 'true' ? undefined : function (feature) {
+                            style: !scope.liveMeasure ? undefined : function (feature) {
                                 const geometry = feature.getGeometry();
                                 if (geometry.getType() !== 'Point') {
                                     const projection = MapService.getMap().getView().getProjection();
@@ -355,6 +355,7 @@ angular.module('anol.draw')
                             scope.activeLayer.olLayer.getSource().removeFeature(selectedFeature);
                             modifyControl.interactions[0].getFeatures().clear();
                             selectedFeature = undefined;
+                            ensureMeasureOverlayRemoved();
                         }
                     };
 

--- a/src/modules/draw/draw-directive.js
+++ b/src/modules/draw/draw-directive.js
@@ -468,7 +468,7 @@ angular.module('anol.draw')
                             scope.map.addInteraction(interaction);
                         });
 
-                        scope.activeLayer = layer
+                        scope.activeLayer = layer;
                         // inital setup in case the active layer already contains features
                         setContinueDrawing();
 

--- a/src/modules/draw/draw-directive.js
+++ b/src/modules/draw/draw-directive.js
@@ -445,8 +445,10 @@ angular.module('anol.draw')
                     var visibleDewatcher;
 
                     var bindActiveLayer = function(layer) {
-                        layer.style = scope.style;
-                        layer.setStyle();
+                        if (angular.isDefined(scope.style)) {
+                            layer.style = scope.style;
+                            layer.setStyle();
+                        }
 
                         drawPointControl.interactions = createDrawInteractions(
                             'Point', layer.olLayer.getSource(), drawPointControl, layer.olLayer);

--- a/src/modules/draw/draw-directive.js
+++ b/src/modules/draw/draw-directive.js
@@ -19,6 +19,8 @@ angular.module('anol.draw')
  * @requires anol.map.ControlsSerivce
  * @requries anol.map.DrawService
  *
+ * @param {object} geometries The configuration of the geometries (e.g. min/max values).
+ * @param {object} style The style for the geometries.
  * @param {boolean} continueDrawing Don't deactivate drawing after feature is added
  * @param {function} postDrawAction Action to call after feature is drawn. Draw control will be deactivated when postDrawAction defined.
  * @param {boolean} freeDrawing Deactivate snapped drawing

--- a/src/modules/draw/draw-directive.js
+++ b/src/modules/draw/draw-directive.js
@@ -38,6 +38,8 @@ angular.module('anol.draw')
                 restrict: 'A',
                 require: '?^anolMap',
                 scope: {
+                    geometries: '=',
+                    style: '=geometriesStyle',
                     continueDrawing: '@',
                     postDrawAction: '&',
                     freeDrawing: '@',
@@ -62,6 +64,7 @@ angular.module('anol.draw')
                         });
                     } 
                     // attribute defaults
+                    scope.geometriesConfig = applyGeometriesConfig(scope.geometries);
                     scope.continueDrawing = angular.isDefined(scope.continueDrawing) ?
                         scope.continueDrawing : false;
                     scope.freeDrawing = angular.isDefined(scope.freeDrawing) ?
@@ -86,6 +89,22 @@ angular.module('anol.draw')
                     // disabled by default. Will be enabled, when feature selected
                     var removeButtonElement = element.find('.draw-remove');
                     removeButtonElement.addClass('disabled');
+
+                    function applyGeometriesConfig(geometries = {}) {
+                        var defaultVals = {
+                            enabled: true,
+                            min: 0,
+                            max: Infinity
+                        };
+
+                        var defaultGeometries = {
+                            point: angular.copy(defaultVals),
+                            line: angular.copy(defaultVals),
+                            polygon: angular.copy(defaultVals)
+                        };
+
+                        return angular.merge(defaultGeometries, geometries);
+                    }
 
                     var executePostDrawCallback = function(evt) {
                         scope.postDrawAction()(scope.activeLayer, evt.feature);
@@ -414,9 +433,21 @@ angular.module('anol.draw')
                             .concat(modifyControl.interactions);
                     };
 
+                    var setContinueDrawing = function() {
+                        var pointCount = DrawService.countFeaturesFor('Point');
+                        var lineCount = DrawService.countFeaturesFor('LineString');
+                        var polygonCount = DrawService.countFeaturesFor('Polygon');
+                        scope.continueDrawingPoints = pointCount < scope.geometriesConfig.point.max;
+                        scope.continueDrawingLines = lineCount < scope.geometriesConfig.line.max;
+                        scope.continueDrawingPolygons = polygonCount < scope.geometriesConfig.polygon.max;
+                    };
+
                     var visibleDewatcher;
 
                     var bindActiveLayer = function(layer) {
+                        layer.style = scope.style;
+                        layer.setStyle();
+
                         drawPointControl.interactions = createDrawInteractions(
                             'Point', layer.olLayer.getSource(), drawPointControl, layer.olLayer);
                         drawPointControl.enable();
@@ -433,7 +464,11 @@ angular.module('anol.draw')
                             scope.map.addInteraction(interaction);
                         });
 
-                        scope.activeLayer = layer;
+                        scope.activeLayer = layer
+                        // inital setup in case the active layer already contains features
+                        setContinueDrawing();
+
+                        scope.activeLayer.olLayer.getSource().on('change', setContinueDrawing);
 
                         visibleDewatcher = scope.$watch(function() {
                             return scope.activeLayer.getVisible();
@@ -459,8 +494,13 @@ angular.module('anol.draw')
                         modifyControl.disable();
                         modifyControl.interactions = [];
 
+
                         if(angular.isDefined(visibleDewatcher)) {
                             visibleDewatcher();
+                        }
+
+                        if (scope.activeLayer && scope.activeLayer.olLayer) {
+                            scope.activeLayer.olLayer.getSource().un('change', setContinueDrawing);
                         }
 
                         scope.activeLayer = undefined;

--- a/src/modules/draw/draw-service.js
+++ b/src/modules/draw/draw-service.js
@@ -60,6 +60,26 @@ angular.module('anol.draw')
                     this.activeLayer = layer;
                 }
             };
+
+            /**
+             * @ngdoc method
+             * @name countFeaturesFor
+             * @methodOf anol.draw.DrawService
+             * @param {String} geometryType Geometry type (e.g. 'Point', 'LineString')
+             * @description
+             * Counts the features in this.activeLayer for the given geometry type.
+             */
+            DrawService.prototype.countFeaturesFor = function(geometryType) {
+                if (angular.isUndefined(this.activeLayer) || angular.isUndefined(geometryType)) {
+                    return;
+                }
+
+                var features = this.activeLayer.olLayer.getSource().getFeatures();
+                return features.filter(function(feature) {
+                    return geometryType === feature.getGeometry().getType();
+                }).length;
+            };
+
             return new DrawService(_editableLayers);
         }];
     }]);

--- a/src/modules/draw/module.js
+++ b/src/modules/draw/module.js
@@ -6,4 +6,4 @@
  */
 import { anol } from '../../anol/anol.js';
 
-angular.module('anol.draw', ['anol.map']);
+angular.module('anol.draw', ['anol.map', 'anol.measure']);

--- a/src/modules/draw/templates/draw.html
+++ b/src/modules/draw/templates/draw.html
@@ -1,4 +1,5 @@
 <button ng-click="drawPoint()"
+        ng-disabled="!geometriesConfig.point.enabled || !continueDrawingPoints"
         class="draw-button draw-point"
         uib-tooltip="{{ 'anol.draw.TOOLTIP_POINT' | translate }}"
         tooltip-placement="{{ pointTooltipPlacement }}"
@@ -8,6 +9,7 @@
         tooltip-trigger="mouseenter">
 </button>
 <button ng-click="drawLine()"
+        ng-disabled="!geometriesConfig.line.enabled || !continueDrawingLines"
         class="draw-button draw-line"
         uib-tooltip="{{ 'anol.draw.TOOLTIP_LINE' | translate }}"
         tooltip-placement="{{ lineTooltipPlacement }}"
@@ -17,6 +19,7 @@
         tooltip-trigger="mouseenter">
 </button>
 <button ng-click="drawPolygon()"
+        ng-disabled="!geometriesConfig.polygon.enabled || !continueDrawingPolygons"
         class="draw-button draw-polygon"
         uib-tooltip="{{ 'anol.draw.TOOLTIP_POLYGON' | translate }}"
         tooltip-placement="{{ polygonTooltipPlacement }}"

--- a/src/modules/featureform/featureform-directive.js
+++ b/src/modules/featureform/featureform-directive.js
@@ -27,8 +27,8 @@ angular.module('anol.featureform')
      * @param {anol.layer.Feature} layer Layer of feature
      * @param {FormField[]} pointFields The form fields for points
      * @param {FormField[]} lineFields The form fields for lines
-     * @param {FormField[]} polygonFields TThe form fields for polygons
-     * @param {Object<string, string>} formValues The values for each form field
+     * @param {FormField[]} polygonFields The form fields for polygons
+     * @param {boolean} [highlightInvalid] show if fields are invalid
      *
      * @description
      * Creates a form to edit defined feature properties.
@@ -42,9 +42,10 @@ angular.module('anol.featureform')
                 scope: {
                     'feature': '=',
                     'layer': '=', // TODO: is this needed?
-                    'pointFields': '=',
-                    'lineFields': '=',
-                    'polygonFields': '='
+                    'pointFields': '=?',
+                    'lineFields': '=?',
+                    'polygonFields': '=?',
+                    'highlightInvalid': '=?'
                 },
                 template: function(tElement, tAttrs) {
                     if (tAttrs.templateUrl) {
@@ -118,6 +119,17 @@ angular.module('anol.featureform')
                      */
                     scope.getOptionLabel = function (option) {
                         return angular.isObject(option) ? option.label || option.value : option;
+                    };
+
+                    /**
+                     * @param {FormField} field
+                     * @return {boolean}
+                     */
+                    scope.isValid = function (field) {
+                        if (field.required) {
+                            return !!scope.properties[field.name];
+                        }
+                        return true;
                     };
 
                     scope.$watch('feature', featureChangeHandler);

--- a/src/modules/featureform/featureform-directive.js
+++ b/src/modules/featureform/featureform-directive.js
@@ -45,7 +45,7 @@ angular.module('anol.featureform')
                     'pointFields': '=?',
                     'lineFields': '=?',
                     'polygonFields': '=?',
-                    'highlightInvalid': '=?'
+                    'highlightInvalid': '<?'
                 },
                 template: function(tElement, tAttrs) {
                     if (tAttrs.templateUrl) {
@@ -127,7 +127,15 @@ angular.module('anol.featureform')
                      */
                     scope.isValid = function (field) {
                         if (field.required) {
-                            return !!scope.properties[field.name];
+                            const value = scope.properties[field.name];
+                            switch (field.type) {
+                            case 'int':
+                            case 'float':
+                                return angular.isNumber(value);
+                            case 'text':
+                            case 'select':
+                                return angular.isString(value) && value !== '';
+                            }
                         }
                         return true;
                     };

--- a/src/modules/featureform/featureform-directive.js
+++ b/src/modules/featureform/featureform-directive.js
@@ -2,7 +2,7 @@ import './module.js';
 
 /**
  * @typedef {object} SelectOption
- * @property {string} label
+ * @property {string} [label]
  * @property {string} value
  */
 
@@ -10,8 +10,8 @@ import './module.js';
  * @typedef {object} FormField
  * @property {string} name the name of the property
  * @property {string} type the type of the input
- * @property {string} label the label of the input
- * @property {string[]} select the available options if type=='select'
+ * @property {string} [label] the label of the input
+ * @property {Array<SelectOption|string>} select the available options if type=='select'
  * @property {boolean} [required]
  */
 
@@ -21,31 +21,26 @@ angular.module('anol.featureform')
      * @name anol.featureform.directive:anolFeatureForm
      *
      * @restrict A
-     * @requires pascalprecht.$translate
      *
      * @param {string} templateUrl Url to template to use instead of default one
      * @param {ol.Feature} feature Feature to show properties for
      * @param {anol.layer.Feature} layer Layer of feature
      * @param {FormField[]} formFields The options for each form field
      * @param {Object<string, string>} formValues The values for each form field
-     * @param {string} translationNamespace Namespace to use in translation table. Default "featureform".
      *
      * @description
      * Creates a form to edit defined feature properties.
      *
      */
-    .directive('anolFeatureForm', ['$templateRequest', '$compile', '$translate',
-        function($templateRequest, $compile, $translate) {
+    .directive('anolFeatureForm', ['$templateRequest', '$compile',
+        function($templateRequest, $compile) {
             return {
                 restrict: 'A',
                 require: '?^anolFeaturePopup',
                 scope: {
                     'feature': '=',
                     'layer': '=', // TODO: is this needed?
-                    'selects': '=', // TODO: is this needed?
-                    'formFields': '=',
-                    'formValues': '=',
-                    'translationNamespace': '@' // TODO: is this needed?
+                    'formFields': '='
                 },
                 template: function(tElement, tAttrs) {
                     if (tAttrs.templateUrl) {
@@ -61,76 +56,48 @@ angular.module('anol.featureform')
                             $compile(template)(scope);
                         });
                     }
-                    //
-                    // scope.$watch('formFields', function (formFields) {
-                    //     console.log(formFields)
-                    // });
-                //     scope.translationNamespace = angular.isDefined(scope.translationNamespace) ?
-                //         scope.translationNamespace : 'featureform';
-                //
-                //     scope.propertiesCollection = [];
-                //
-                //     var featureChangeHandler = function(feature) {
-                //         var propertiesCollection = [];
-                //         if(angular.isUndefined(scope.layer) || !angular.isObject(scope.layer.featureinfo)) {
-                //             scope.propertiesCollection = propertiesCollection;
-                //         } else {
-                //             var properties = propertiesFromFeature(feature, scope.layer.name, scope.layer.featureinfo.properties);
-                //             if(!angular.equals(properties, {})) {
-                //                 propertiesCollection.push(properties);
-                //             }
-                //             scope.propertiesCollection = propertiesCollection;
-                //         }
-                //         if(FeaturePopupController !== null && scope.propertiesCollection.length === 0) {
-                //             FeaturePopupController.close();
-                //         }
-                //     };
-                //
-                //     var selectsChangeHandler = function(selects) {
-                //         var propertiesCollection = [];
-                //         angular.forEach(selects, function(selectObj) {
-                //             var layer = selectObj.layer;
-                //             var features = selectObj.features;
-                //             if(!angular.isObject(layer.featureinfo) || features.length === 0) {
-                //                 return;
-                //             }
-                //             angular.forEach(features, function(feature) {
-                //                 var properties = propertiesFromFeature(feature, layer.name, layer.featureinfo.properties);
-                //                 if(!angular.equals(properties, {})) {
-                //                     propertiesCollection.push(properties);
-                //                 }
-                //             });
-                //         });
-                //         scope.propertiesCollection = propertiesCollection;
-                //         if(FeaturePopupController !== null && scope.propertiesCollection.length === 0) {
-                //             FeaturePopupController.close();
-                //         }
-                //     };
-                //
-                //     scope.$watch('feature', featureChangeHandler);
-                //     scope.$watchCollection('selects', selectsChangeHandler);
+
+                    scope.properties = {};
+
+                    /**
+                     * @param {ol.Feature} feature
+                     */
+                    var featureChangeHandler = function (feature) {
+                        if (feature) {
+                            scope.properties = feature.getProperties();
+                        }
+                    };
+
+                    /**
+                     * @param {FormField[]} formFields
+                     */
+                    var formFieldChangeHandler = function (formFields) {
+                        formFields.forEach(function (field) {
+                            scope.$watch('properties["' + field.name + '"]', function (value) {
+                                scope.feature.set(field.name, value);
+                            });
+                        });
+                    };
+
+                    /**
+                     * @param {SelectOption|string} option
+                     * @return {string}
+                     */
+                    scope.getOptionValue = function (option) {
+                        return angular.isObject(option) ? option.value : option;
+                    };
+
+                    /**
+                     * @param {SelectOption|string} option
+                     * @return {string}
+                     */
+                    scope.getOptionLabel = function (option) {
+                        return angular.isObject(option) ? option.label || option.value : option;
+                    };
+
+                    scope.$watch('feature', featureChangeHandler);
+
+                    scope.$watch('formFields', formFieldChangeHandler);
                 }
             };
         }]);
-
-    // .directive('urlOrText', [function() {
-    //     return {
-    //         restrict: 'E',
-    //         scope: {
-    //             url: '=value'
-    //         },
-    //         link: function(scope, element) {
-    //             var isUrl = function(s) {
-    //                 var regexp = /(http:\/\/|https:\/\/|www\.)/;
-    //                 return regexp.test(s);
-    //             };
-    //             scope.$watch('url', function(url) {
-    //                 var content = url;
-    //                 if(isUrl(url)) {
-    //                     content = $('<a href="' + url + '">' + url + '</a>');
-    //                 }
-    //                 element.html(content);
-    //             });
-    //         }
-    //     };
-    // }]);

--- a/src/modules/featureform/featureform-directive.js
+++ b/src/modules/featureform/featureform-directive.js
@@ -1,0 +1,136 @@
+import './module.js';
+
+/**
+ * @typedef {object} SelectOption
+ * @property {string} label
+ * @property {string} value
+ */
+
+/**
+ * @typedef {object} FormField
+ * @property {string} name the name of the property
+ * @property {string} type the type of the input
+ * @property {string} label the label of the input
+ * @property {string[]} select the available options if type=='select'
+ * @property {boolean} [required]
+ */
+
+angular.module('anol.featureform')
+    /**
+     * @ngdoc directive
+     * @name anol.featureform.directive:anolFeatureForm
+     *
+     * @restrict A
+     * @requires pascalprecht.$translate
+     *
+     * @param {string} templateUrl Url to template to use instead of default one
+     * @param {ol.Feature} feature Feature to show properties for
+     * @param {anol.layer.Feature} layer Layer of feature
+     * @param {FormField[]} formFields The options for each form field
+     * @param {Object<string, string>} formValues The values for each form field
+     * @param {string} translationNamespace Namespace to use in translation table. Default "featureform".
+     *
+     * @description
+     * Creates a form to edit defined feature properties.
+     *
+     */
+    .directive('anolFeatureForm', ['$templateRequest', '$compile', '$translate',
+        function($templateRequest, $compile, $translate) {
+            return {
+                restrict: 'A',
+                require: '?^anolFeaturePopup',
+                scope: {
+                    'feature': '=',
+                    'layer': '=', // TODO: is this needed?
+                    'selects': '=', // TODO: is this needed?
+                    'formFields': '=',
+                    'formValues': '=',
+                    'translationNamespace': '@' // TODO: is this needed?
+                },
+                template: function(tElement, tAttrs) {
+                    if (tAttrs.templateUrl) {
+                        return '<div></div>';
+                    }
+                    return require('./templates/featureform.html');
+                },
+                link: function(scope, element, attrs, FeaturePopupController) {
+                    if (attrs.templateUrl && attrs.templateUrl !== '') {
+                        $templateRequest(attrs.templateUrl).then(function(html){
+                            var template = angular.element(html);
+                            element.html(template);
+                            $compile(template)(scope);
+                        });
+                    }
+                    //
+                    // scope.$watch('formFields', function (formFields) {
+                    //     console.log(formFields)
+                    // });
+                //     scope.translationNamespace = angular.isDefined(scope.translationNamespace) ?
+                //         scope.translationNamespace : 'featureform';
+                //
+                //     scope.propertiesCollection = [];
+                //
+                //     var featureChangeHandler = function(feature) {
+                //         var propertiesCollection = [];
+                //         if(angular.isUndefined(scope.layer) || !angular.isObject(scope.layer.featureinfo)) {
+                //             scope.propertiesCollection = propertiesCollection;
+                //         } else {
+                //             var properties = propertiesFromFeature(feature, scope.layer.name, scope.layer.featureinfo.properties);
+                //             if(!angular.equals(properties, {})) {
+                //                 propertiesCollection.push(properties);
+                //             }
+                //             scope.propertiesCollection = propertiesCollection;
+                //         }
+                //         if(FeaturePopupController !== null && scope.propertiesCollection.length === 0) {
+                //             FeaturePopupController.close();
+                //         }
+                //     };
+                //
+                //     var selectsChangeHandler = function(selects) {
+                //         var propertiesCollection = [];
+                //         angular.forEach(selects, function(selectObj) {
+                //             var layer = selectObj.layer;
+                //             var features = selectObj.features;
+                //             if(!angular.isObject(layer.featureinfo) || features.length === 0) {
+                //                 return;
+                //             }
+                //             angular.forEach(features, function(feature) {
+                //                 var properties = propertiesFromFeature(feature, layer.name, layer.featureinfo.properties);
+                //                 if(!angular.equals(properties, {})) {
+                //                     propertiesCollection.push(properties);
+                //                 }
+                //             });
+                //         });
+                //         scope.propertiesCollection = propertiesCollection;
+                //         if(FeaturePopupController !== null && scope.propertiesCollection.length === 0) {
+                //             FeaturePopupController.close();
+                //         }
+                //     };
+                //
+                //     scope.$watch('feature', featureChangeHandler);
+                //     scope.$watchCollection('selects', selectsChangeHandler);
+                }
+            };
+        }]);
+
+    // .directive('urlOrText', [function() {
+    //     return {
+    //         restrict: 'E',
+    //         scope: {
+    //             url: '=value'
+    //         },
+    //         link: function(scope, element) {
+    //             var isUrl = function(s) {
+    //                 var regexp = /(http:\/\/|https:\/\/|www\.)/;
+    //                 return regexp.test(s);
+    //             };
+    //             scope.$watch('url', function(url) {
+    //                 var content = url;
+    //                 if(isUrl(url)) {
+    //                     content = $('<a href="' + url + '">' + url + '</a>');
+    //                 }
+    //                 element.html(content);
+    //             });
+    //         }
+    //     };
+    // }]);

--- a/src/modules/featureform/module.js
+++ b/src/modules/featureform/module.js
@@ -1,0 +1,9 @@
+/**
+ * @ngdoc overview
+ * @name anol.featureform
+ * @description
+ * Module providing the featureform directive
+ */
+import { anol } from '../../anol/anol.js';
+
+angular.module('anol.featureform', ['anol.map']);

--- a/src/modules/featureform/templates/featureform.html
+++ b/src/modules/featureform/templates/featureform.html
@@ -2,17 +2,31 @@
     <div ng-repeat="field in formFields"
          class="form-group"
          ng-class="{ 'has-error': highlightInvalid && !isValid(field) }"
+         ng-switch="field.type"
     >
         <label for="input-{{field.name}}">
             {{ field.label || field.name }}{{ field.required ? ' (*)' : ''}}
         </label>
-        <input ng-if="field.type !== 'select'"
+        <input ng-switch-when="text"
                id="input-{{field.name}}"
                class="form-control"
-               type="{{field.type}}"
+               type="text"
                ng-model="properties[field.name]"
         />
-        <select ng-if="field.type === 'select'"
+        <input ng-switch-when="int"
+               id="input-{{field.name}}"
+               class="form-control"
+               type="number"
+               ng-model="properties[field.name]"
+        />
+        <input ng-switch-when="float"
+               id="input-{{field.name}}"
+               class="form-control"
+               type="number"
+               step="any"
+               ng-model="properties[field.name]"
+        />
+        <select ng-switch-when="select"
                 id="input-{{field.name}}"
                 class="form-control"
                 ng-model="properties[field.name]"
@@ -26,6 +40,9 @@
                 {{ getOptionLabel(option) }}
             </option>
         </select>
+        <div ng-switch-default>
+            {{ 'anol.featureform.INPUT_NOT_SUPPORTED' | translate }}"{{ field.type }}"
+        </div>
         <small ng-if="highlightInvalid && !isValid(field)"
                class="help-block">
             {{ 'anol.featureform.IS_REQUIRED' | translate }}

--- a/src/modules/featureform/templates/featureform.html
+++ b/src/modules/featureform/templates/featureform.html
@@ -1,11 +1,35 @@
 <form class="container-fluid" style="padding-top: 2em">
-    <div ng-repeat="field in formFields" class="form-group">
-        <label for="input-{{field.name}}">{{ field.label || field.name }}</label>
-        <input ng-if="field.type !== 'select'" class="form-control" type="{{field.type}}" id="input-{{field.name}}" ng-model="properties[field.name]"/>
-        <select ng-if="field.type === 'select'" class="form-control" id="input-{{field.name}}" ng-model="properties[field.name]">
-            <option value="">{{ 'anol.featureform.PLEASE_CHOOSE' | translate }}</option>
-            <option ng-repeat="option in field.select" ng-value="getOptionValue(option)">{{ getOptionLabel(option) }}</option>
+    <div ng-repeat="field in formFields"
+         class="form-group"
+         ng-class="{ 'has-error': highlightInvalid && !isValid(field) }"
+    >
+        <label for="input-{{field.name}}">
+            {{ field.label || field.name }}{{ field.required ? ' (*)' : ''}}
+        </label>
+        <input ng-if="field.type !== 'select'"
+               id="input-{{field.name}}"
+               class="form-control"
+               type="{{field.type}}"
+               ng-model="properties[field.name]"
+        />
+        <select ng-if="field.type === 'select'"
+                id="input-{{field.name}}"
+                class="form-control"
+                ng-model="properties[field.name]"
+        >
+            <option value="">
+                {{ 'anol.featureform.PLEASE_CHOOSE' | translate }}
+            </option>
+            <option ng-repeat="option in field.select"
+                    ng-value="getOptionValue(option)"
+            >
+                {{ getOptionLabel(option) }}
+            </option>
         </select>
+        <small ng-if="highlightInvalid && !isValid(field)"
+               class="help-block">
+            {{ 'anol.featureform.IS_REQUIRED' | translate }}
+        </small>
     </div>
 </form>
 

--- a/src/modules/featureform/templates/featureform.html
+++ b/src/modules/featureform/templates/featureform.html
@@ -1,10 +1,10 @@
 <form class="container-fluid" style="padding-top: 2em">
     <div ng-repeat="field in formFields" class="form-group">
-        <label for="input-{{field.name}}">{{ field.label }}</label>
-        <input ng-if="field.type !== 'select'" class="form-control" type="{{field.type}}" id="input-{{field.name}}" ng-model="formValues[field.name]"/>
-        <select ng-if="field.type === 'select'" class="form-control" id="input-{{field.name}}"  ng-model="formValues[field.name]">
+        <label for="input-{{field.name}}">{{ field.label || field.name }}</label>
+        <input ng-if="field.type !== 'select'" class="form-control" type="{{field.type}}" id="input-{{field.name}}" ng-model="properties[field.name]"/>
+        <select ng-if="field.type === 'select'" class="form-control" id="input-{{field.name}}" ng-model="properties[field.name]">
             <option value="">{{ 'anol.featureform.PLEASE_CHOOSE' | translate }}</option>
-            <option ng-repeat="option in field.select" ng-value="option.value">{{ option.label }}</option>
+            <option ng-repeat="option in field.select" ng-value="getOptionValue(option)">{{ getOptionLabel(option) }}</option>
         </select>
     </div>
 </form>

--- a/src/modules/featureform/templates/featureform.html
+++ b/src/modules/featureform/templates/featureform.html
@@ -1,0 +1,11 @@
+<form class="container-fluid" style="padding-top: 2em">
+    <div ng-repeat="field in formFields" class="form-group">
+        <label for="input-{{field.name}}">{{ field.label }}</label>
+        <input ng-if="field.type !== 'select'" class="form-control" type="{{field.type}}" id="input-{{field.name}}" ng-model="formValues[field.name]"/>
+        <select ng-if="field.type === 'select'" class="form-control" id="input-{{field.name}}"  ng-model="formValues[field.name]">
+            <option value="">{{ 'anol.featureform.PLEASE_CHOOSE' | translate }}</option>
+            <option ng-repeat="option in field.select" ng-value="option.value">{{ option.label }}</option>
+        </select>
+    </div>
+</form>
+

--- a/src/modules/featurepropertieseditor/templates/featurepropertieseditor.html
+++ b/src/modules/featurepropertieseditor/templates/featurepropertieseditor.html
@@ -6,7 +6,7 @@
     </div>
     <div class="col-sm-2">
       <button type="button" class="btn btn-danger btn-sm" ng-click="removeProperty(key)">
-        <span class="glyphicon glyphicon-remove"</span>
+        <span class="glyphicon glyphicon-remove"></span>
       </button>
     </div>
   </div>

--- a/src/modules/measure/measure-service.js
+++ b/src/modules/measure/measure-service.js
@@ -1,0 +1,222 @@
+import './module.js';
+
+import { Circle as CircleStyle, Fill, Stroke, Style, Text } from 'ol/style.js';
+import Point from 'ol/geom/Point';
+import LineString from 'ol/geom/LineString';
+import { transform } from 'ol/proj';
+import Overlay from 'ol/Overlay';
+import MultiPoint from 'ol/geom/MultiPoint.js';
+import { getArea as getSphereArea, getDistance } from 'ol/sphere';
+
+angular.module('anol.measure')
+    /**
+     * @ngdoc object
+     * @name anol.measure.MeasureServiceFactory
+     */
+    .factory('MeasureService', ['MapService', function (MapService) {
+
+        function createMeasureOverlay() {
+            var element = angular.element('<div></div>');
+            element.addClass('anol-overlay');
+            element.addClass('anol-measure-overlay');
+            var overlay = new Overlay({
+                element: element[0],
+                offset: [0, -15],
+                positioning: 'bottom-center'
+            });
+            return overlay;
+        };
+
+        function calculateLength(geometry, projection, geodesic) {
+            if (geometry.getType() !== 'LineString') {
+                return 0;
+            }
+            var length;
+            if (geodesic) {
+                var coordinates = geometry.getCoordinates();
+                length = 0;
+                for (var i = 0, ii = coordinates.length - 1; i < ii; ++i) {
+                    var c1 = transform(coordinates[i], projection.getCode(), 'EPSG:4326');
+                    var c2 = transform(coordinates[i + 1], projection.getCode(), 'EPSG:4326');
+                    length += getDistance(c1, c2);
+                }
+            } else {
+                length = Math.round(geometry.getLength() * 100) / 100;
+            }
+            return length;
+        };
+
+        function calculateArea(geometry, projection, geodesic) {
+            if (geometry.getType() !== 'Polygon') {
+                return 0.0;
+            }
+            var area;
+            if (geodesic) {
+                area = getSphereArea(geometry);
+            } else {
+                area = geometry.getArea();
+            }
+            return area;
+        };
+
+        function formatLineResult(geometry, projection, geodesic) {
+            var length = calculateLength(geometry, projection, geodesic);
+            var output;
+            if (length > 1000) {
+                output = anol.helper.round((length / 1000), 3) + ' ' + 'km';
+            } else {
+                output = anol.helper.round(length, 2) + ' ' + 'm';
+            }
+            output = output.replace('.', ',')
+            return output;
+        };
+
+        function formatAreaResult(geometry, projection, geodesic, addCircumference) {
+            var area = calculateArea(geometry, projection, geodesic);
+            if (area === 0) {
+                return '';
+            }
+
+            var output;
+            if (area > 100000) {
+                output = anol.helper.round((area / 10000), 3) +
+                    ' ' + 'ha';
+            } else {
+                output = anol.helper.round(area, 2) +
+                    ' ' + 'm<sup>2</sup>';
+            }
+            output = output.replace('.', ',')
+
+            if (addCircumference) {
+                // calculate line length for area and add to label
+                var length = 0;
+                var coordinates = geometry.getCoordinates();
+                var coords = coordinates[0];
+                angular.forEach(coords, function (coord, idx) {
+                    if (idx !== coords.length - 1) {
+                        length += calculateLength(new LineString([coord, coords[idx + 1]]));
+                    }
+                })
+                if (length > 1000) {
+                    output += '<br>' + anol.helper.round((length / 1000), 3) + ' ' + 'km';
+                } else {
+                    output += '<br>' + anol.helper.round(length, 2) + ' ' + 'm';
+                }
+                output = output.replace('.', ',')
+            }
+
+            return output;
+        };
+
+        var measureStyle = function (feature, labelSegments) {
+            var geometry = feature.getGeometry();
+            var styles = [
+                new Style({
+                    fill: new Fill({
+                        color: 'rgba(255, 255, 255, 0.2)'
+                    }),
+                    stroke: new Stroke({
+                        color: 'rgba(0, 0, 0, 0.5)',
+                        lineDash: [10, 10],
+                        width: 2,
+                        opacity: 0.5
+                    }),
+                    image: new CircleStyle({
+                        radius: 5,
+                        stroke: new Stroke({
+                            color: 'rgba(0, 0, 0, 0.7)'
+                        })
+                    })
+                })
+            ];
+
+            function lengthAsString(start, end) {
+                var geometry = new LineString([start, end])
+                var projection = MapService.getMap().getView().getProjection();
+
+                var length;
+                // TODO load from Service
+                var geodesic = false;
+
+                if (geodesic) {
+                    var coordinates = geometry.getCoordinates();
+                    length = 0;
+                    for (var i = 0, ii = coordinates.length - 1; i < ii; ++i) {
+                        var c1 = transform(coordinates[i], projection.getCode(), 'EPSG:4326');
+                        var c2 = transform(coordinates[i + 1], projection.getCode(), 'EPSG:4326');
+                        length += getDistance(c1, c2);
+                    }
+                } else {
+                    length = Math.round(geometry.getLength() * 100) / 100;
+                }
+
+                var output;
+                if (length > 1000) {
+                    output = anol.helper.round((length / 1000), 3) + ' ' + 'km';
+                } else {
+                    output = anol.helper.round(length, 2) + ' ' + 'm';
+                }
+                output = output.replace('.', ',')
+                return output;
+            }
+
+            function layoutSegments(start, end) {
+                var newXY = [(end[0] + start[0]) / 2, (end[1] + start[1]) / 2];
+                // text
+                styles.push(new Style({
+                    geometry: new Point(newXY),
+                    text: new Text({
+                        font: '14px Calibri,sans-serif',
+                        fill: new Fill({
+                            color: '#000'
+                        }),
+                        stroke: new Stroke({
+                            color: '#fff',
+                            width: 2
+                        }),
+                        text: lengthAsString(start, end)
+                    })
+                }));
+                // points
+                styles.push(new Style({
+                    geometry: new MultiPoint([start, end]),
+                    image: new CircleStyle({
+                        radius: 5,
+                        fill: new Fill({
+                            color: 'grey'
+                        })
+                    })
+                }));
+            }
+
+            if (labelSegments) {
+                var geometryType = feature.getGeometry().getType();
+                if (geometryType === 'LineString') {
+                    geometry.forEachSegment(function (start, end) {
+                        layoutSegments(start, end);
+                    });
+                }
+                if (geometryType === 'Polygon') {
+                    var coordinates = geometry.getCoordinates();
+                    var coords = coordinates[0];
+                    angular.forEach(coords, function (coord, idx) {
+                        if (idx !== coords.length - 1) {
+                            var start = coord;
+                            var end = coords[idx + 1];
+                            layoutSegments(start, end);
+                        }
+                    })
+                }
+            }
+            return styles;
+        };
+
+        return {
+            createMeasureOverlay: createMeasureOverlay,
+            measureStyle: measureStyle,
+            calculateLength: calculateLength,
+            calculateArea: calculateLength,
+            formatLineResult: formatLineResult,
+            formatAreaResult: formatAreaResult
+        };
+    }]);

--- a/src/modules/module.js
+++ b/src/modules/module.js
@@ -131,7 +131,7 @@ angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
                     'TOOLTIP_DRAW_POINT': 'Punkt zeichnen',
                     'TOOLTIP_DRAW_LINE': 'Linie zeichnen',
                     'TOOLTIP_DRAW_POLYGON': 'Polygon zeichnen',
-                    'TOOLTIP_REMOVE': 'Ausgewählte Geometry entfernen',
+                    'TOOLTIP_REMOVE': 'Ausgewählte Geometrie entfernen',
                     'DRAW_LAYER_TITLE': 'Zeichenlayer'
                 },
                 'featurestyleeditor': {

--- a/src/modules/module.js
+++ b/src/modules/module.js
@@ -46,7 +46,8 @@ angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
                     'COULD_NOT_READ_FILE': 'Could not read file'
                 },
                 'featureform': {
-                    'PLEASE_CHOOSE': 'Please choose ...'
+                    'PLEASE_CHOOSE': 'Please choose ...',
+                    'IS_REQUIRED': 'This field is required'
                 },
                 'featurepropertieseditor': {
                     'NEW_PROPERTY': 'New property'
@@ -138,7 +139,8 @@ angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
                     'DRAW_LAYER_TITLE': 'Zeichenlayer'
                 },
                 'featureform': {
-                    'PLEASE_CHOOSE': 'Bitte auswählen ...'
+                    'PLEASE_CHOOSE': 'Bitte auswählen ...',
+                    'IS_REQUIRED': 'Dies ist ein Pflichtfeld'
                 },
                 'featurestyleeditor': {
                     'EDIT_FEATURE_STYLE': 'Feature Style bearbeiten',

--- a/src/modules/module.js
+++ b/src/modules/module.js
@@ -47,7 +47,8 @@ angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
                 },
                 'featureform': {
                     'PLEASE_CHOOSE': 'Please choose ...',
-                    'IS_REQUIRED': 'This field is required'
+                    'IS_REQUIRED': 'This field is required',
+                    'INPUT_NOT_SUPPORTED': 'The following configured input type is not supported: '
                 },
                 'featurepropertieseditor': {
                     'NEW_PROPERTY': 'New property'
@@ -140,7 +141,8 @@ angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
                 },
                 'featureform': {
                     'PLEASE_CHOOSE': 'Bitte auswählen ...',
-                    'IS_REQUIRED': 'Dies ist ein Pflichtfeld'
+                    'IS_REQUIRED': 'Dies ist ein Pflichtfeld',
+                    'INPUT_NOT_SUPPORTED': 'Der folgende konfigurierte Inputtyp ist nicht unterstützt: '
                 },
                 'featurestyleeditor': {
                     'EDIT_FEATURE_STYLE': 'Feature Style bearbeiten',

--- a/src/modules/module.js
+++ b/src/modules/module.js
@@ -6,11 +6,10 @@
  */
 
 require('angular-ui-bootstrap');
-require('ui-select');
 require('angular-translate');
 require('angular-sanitize');
 
-angular.module('anol', ['ui.bootstrap', 'ui.select', 'pascalprecht.translate', 'ngSanitize'])
+angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
 /**
  * @ngdoc object
  * @name anol.constant:DefaultMapName

--- a/src/modules/module.js
+++ b/src/modules/module.js
@@ -6,7 +6,6 @@
  */
 
 require('angular-ui-bootstrap');
-require('ui-select');
 require('angular-translate');
 require('angular-sanitize');
 

--- a/src/modules/module.js
+++ b/src/modules/module.js
@@ -36,6 +36,7 @@ angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
                     'TOOLTIP_POINT': 'Draw point',
                     'TOOLTIP_LINE': 'Draw line',
                     'TOOLTIP_POLYGON': 'Draw polygon',
+                    'TOOLTIP_REMOVE': 'Remove selected geometry',
                     'LAYER_TITLE': 'Draw layer'
                 },
                 'featureexchange': {
@@ -130,6 +131,7 @@ angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
                     'TOOLTIP_DRAW_POINT': 'Punkt zeichnen',
                     'TOOLTIP_DRAW_LINE': 'Linie zeichnen',
                     'TOOLTIP_DRAW_POLYGON': 'Polygon zeichnen',
+                    'TOOLTIP_REMOVE': 'Ausgewählte Geometry entfernen',
                     'DRAW_LAYER_TITLE': 'Zeichenlayer'
                 },
                 'featurestyleeditor': {

--- a/src/modules/module.js
+++ b/src/modules/module.js
@@ -6,10 +6,11 @@
  */
 
 require('angular-ui-bootstrap');
+require('ui-select');
 require('angular-translate');
 require('angular-sanitize');
 
-angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
+angular.module('anol', ['ui.bootstrap', 'ui.select', 'pascalprecht.translate', 'ngSanitize'])
 /**
  * @ngdoc object
  * @name anol.constant:DefaultMapName
@@ -43,6 +44,9 @@ angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
                     'INVALID_GEOJSON': 'No valid geojson given',
                     'EMPTY_GEOJSON': 'Empty geojson given',
                     'COULD_NOT_READ_FILE': 'Could not read file'
+                },
+                'featureform': {
+                    'PLEASE_CHOOSE': 'Please choose ...'
                 },
                 'featurepropertieseditor': {
                     'NEW_PROPERTY': 'New property'
@@ -132,6 +136,9 @@ angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
                     'TOOLTIP_DRAW_POLYGON': 'Polygon zeichnen',
                     'DRAW_LAYER_TITLE': 'Zeichenlayer'
                 },
+                'featureform': {
+                    'PLEASE_CHOOSE': 'Bitte auswählen ...'
+                },
                 'featurestyleeditor': {
                     'EDIT_FEATURE_STYLE': 'Feature Style bearbeiten',
                     'OK': 'OK',
@@ -158,6 +165,6 @@ angular.module('anol', ['ui.bootstrap', 'pascalprecht.translate', 'ngSanitize'])
             'CHANGE_LANGUAGE': 'Sprache wechseln',
             'ENGLISH': 'Englisch',
             'GERMAN': 'Deutsch'
-        });    
+        });
         $translateProvider.preferredLanguage('en_US');
     }]);


### PR DESCRIPTION
Fixes:

- Ensure that measure overlay is removed when feature is removed
- Fix parameter binding for live-measure parameter. Tested to work: missing attribute (-> false), "true", "false" or scope values ("geoeditor.displayMeasurements")